### PR TITLE
Moves the reply button to the right

### DIFF
--- a/teamsenhanced.css
+++ b/teamsenhanced.css
@@ -14,3 +14,24 @@
 {
 	max-width: 400rem !important;
 }
+
+/* Reply message button: Removes background and border */
+.ts-reply-message .icons-reply.ts-sym
+{
+	background: 0% !important;
+	border: none !important;
+}
+
+/* Reply message button: Moves reply button up and to the right */
+reply-message button[data-tid="replyMessageButtonShort"]
+{
+    margin-top: -28px !important;
+    float: right !important;
+	width: fit-content !important;
+}
+
+/* Reply message button: Removes 'Reply' text */
+reply-message button[data-tid="replyMessageButtonShort"] span
+{
+	display: none !important;
+}


### PR DESCRIPTION
Known issues:
Reply button overlaps icons when the thread is collapsed:
- attachment icon
- important icon
- mention icon
![image](https://user-images.githubusercontent.com/11963069/82398611-39a60000-9a21-11ea-9621-823eceedcfaf.png)
